### PR TITLE
Enhancement: Arbitrarily close connection

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -97,19 +97,19 @@ install: all wsserver.pc
 	install -m 644 $(INCLUDE)/*.h $(DESTDIR)$(INCDIR)/wsserver
 	@#Manpages
 	install -d $(DESTDIR)$(MANDIR)/man3
-	install -m 0644 $(MANPAGES)/ws_getaddress.3 $(DESTDIR)$(MANDIR)/man3/
-	install -m 0644 $(MANPAGES)/ws_sendframe.3 $(DESTDIR)$(MANDIR)/man3/
-	install -m 0644 $(MANPAGES)/ws_sendframe_bin.3 $(DESTDIR)$(MANDIR)/man3/
-	install -m 0644 $(MANPAGES)/ws_sendframe_txt.3 $(DESTDIR)$(MANDIR)/man3/
-	install -m 0644 $(MANPAGES)/ws_socket.3 $(DESTDIR)$(MANDIR)/man3/
+	install -m 0644 $(MANPAGES)/*.3 $(DESTDIR)$(MANDIR)/man3/
 
 # Uninstall rules
 uninstall:
 	rm -f  $(DESTDIR)$(LIBDIR)/$(LIB)
-	rf -rf $(DESTDIR)$(INCDIR)/wsserver
-	rm -f  $(DESTDIR)$(MANDIR)/man3/{ws_getaddress.3, ws_sendframe.3}
-	rm -f  $(DESTDIR)$(MANDIR)/man3/{ws_sendframe_bin.3, ws_sendframe_txt.3}
-	rm -f  $(DESTDIR)$(MANDIR)/man3/{ws_socket.3}
+	rm -rf $(DESTDIR)$(INCDIR)/wsserver
+	rm -f  $(DESTDIR)$(MANDIR)/man3/ws_getaddress.3
+	rm -f  $(DESTDIR)$(MANDIR)/man3/ws_sendframe.3
+	rm -f  $(DESTDIR)$(MANDIR)/man3/ws_sendframe_bin.3
+	rm -f  $(DESTDIR)$(MANDIR)/man3/ws_sendframe_txt.3
+	rm -f  $(DESTDIR)$(MANDIR)/man3/ws_socket.3
+	rm -f  $(DESTDIR)$(MANDIR)/man3/ws_close_client.3
+	rm -f  $(DESTDIR)$(MANDIR)/man3/ws_get_state.3
 	rm -f  $(DESTDIR)$(PKGDIR)/wsserver.pc
 
 # Generate wsserver.pc
@@ -121,7 +121,7 @@ wsserver.pc:
 	@echo 'Name: wsServer'                >> $(DESTDIR)$(PKGDIR)/wsserver.pc
 	@echo 'Description: Tiny WebSocket Server Library' >> $(DESTDIR)$(PKGDIR)/wsserver.pc
 	@echo 'Version: 1.0'                  >> $(DESTDIR)$(PKGDIR)/wsserver.pc
-	@echo 'Libs: -L$${libdir} -lws'       >> $(DESTDIR)$(PKGDIR)/wsserver.pc
+	@echo 'Libs: -L$${libdir} -lws -pthread' >> $(DESTDIR)$(PKGDIR)/wsserver.pc
 	@echo 'Libs.private:'                 >> $(DESTDIR)$(PKGDIR)/wsserver.pc
 	@echo 'Cflags: -I$${includedir}/wsserver' >> $(DESTDIR)$(PKGDIR)/wsserver.pc
 

--- a/doc/man/man3/ws_close_client.3
+++ b/doc/man/man3/ws_close_client.3
@@ -1,0 +1,38 @@
+.\"
+.\" Copyright (C) 2016-2020  Davidson Francis <davidsondfgl@gmail.com>
+.\"
+.\" This program is free software: you can redistribute it and/or modify
+.\" it under the terms of the GNU General Public License as published by
+.\" the Free Software Foundation, either version 3 of the License, or
+.\" (at your option) any later version.
+.\"
+.\" This program is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" GNU General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with this program.  If not, see <http://www.gnu.org/licenses/>
+.\"
+.TH man 3 "20 Dec 2020" "1.0" "wsServer man page"
+.SH NAME
+ws_close_connection \- Close the client connection.
+.SH SYNOPSIS
+.nf
+.B #include <ws.h>
+.sp
+.BI "int ws_close_client(int " fd ");
+.fi
+.SH DESCRIPTION
+.BR ws_close_client ()
+for a given client
+.I fd
+, closes the client connection with normal close code (1000) and no
+reason string.
+.SH RETURN VALUE
+Returns 0 if success, -1 otherwise.
+.SH NOTES
+If the client did not send a close frame in TIMEOUT_MS ms (500 ms), the
+server will close the connection with error code (1002).
+.SH AUTHOR
+Davidson Francis (davidsondfgl@gmail.com)

--- a/doc/man/man3/ws_get_state.3
+++ b/doc/man/man3/ws_get_state.3
@@ -1,0 +1,46 @@
+.\"
+.\" Copyright (C) 2016-2020  Davidson Francis <davidsondfgl@gmail.com>
+.\"
+.\" This program is free software: you can redistribute it and/or modify
+.\" it under the terms of the GNU General Public License as published by
+.\" the Free Software Foundation, either version 3 of the License, or
+.\" (at your option) any later version.
+.\"
+.\" This program is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" GNU General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with this program.  If not, see <http://www.gnu.org/licenses/>
+.\"
+.TH man 3 "20 Dec 2020" "1.0" "wsServer man page"
+.SH NAME
+ws_get_state \- Get a client current state
+.SH SYNOPSIS
+.nf
+.B #include <ws.h>
+.sp
+.BI "int ws_get_state(int " fd ");
+.fi
+.SH DESCRIPTION
+.BR ws_get_state ()
+for a given client
+.I fd
+, gets the current state. Valid states are:
+.PP
+.RS 2
+.IP \(em 2
+WS_STATE_CONNECTING (0)
+.IP \(em 2
+WS_STATE_OPEN (1)
+.IP \(em 2
+WS_STATE_CLOSING (2)
+.IP \(em 2
+WS_STATE_CLOSED (3)
+.PP
+Anything other than that should be considered an error.
+.SH RETURN VALUE
+Returns the client state or -1 if error.
+.SH AUTHOR
+Davidson Francis (davidsondfgl@gmail.com)

--- a/example/send_receive.html
+++ b/example/send_receive.html
@@ -54,10 +54,12 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>
 		};
 
 		/* Close events. */
-		ws.onclose = function()
+		ws.onclose = function(event)
 		{
 			document.getElementById("btConn").value = "Connect!";
-			document.getElementById("taLog").value += ("Connection closed\n");
+			document.getElementById("taLog").value +=
+				("Connection closed: wasClean: " + event.wasClean + ", evCode: "
+					+ event.code + "\n");
 			scoll_to_bottom();
 			connected = false;
 		};

--- a/include/ws.h
+++ b/include/ws.h
@@ -163,6 +163,28 @@
 	/**@}*/
 
 	/**
+	 * @name Connection states
+	 */
+	/**@{*/
+	/**
+	 * @brief Connection not established yet.
+	 */
+	#define WS_STATE_CONNECTING 0
+	/**
+	 * @brief Communicating.
+	 */
+	#define WS_STATE_OPEN       1
+	/**
+	 * @brief Closing state.
+	 */
+	#define WS_STATE_CLOSING    2
+	/**
+	 * @brief Closed.
+	 */
+	#define WS_STATE_CLOSED     3
+	/**@}*/
+
+	/**
 	 * @name Handshake constants.
 	 */
 	/**@{*/
@@ -212,6 +234,7 @@
 		int fd, const char *msg, ssize_t size, bool broadcast, int type);
 	extern int ws_sendframe_txt(int fd, const char *msg, bool broadcast);
 	extern int ws_sendframe_bin(int fd, const char *msg, size_t size, bool broadcast);
+	extern int ws_get_state(int fd);
 	extern int ws_socket(struct ws_events *evs, uint16_t port);
 
 #ifdef AFL_FUZZ

--- a/include/ws.h
+++ b/include/ws.h
@@ -185,6 +185,20 @@
 	/**@}*/
 
 	/**
+	 * @name Timeout util
+	 */
+	/**@{*/
+	/**
+	 * @brief Nanoseconds macro converter
+	 */
+	#define MS_TO_NS(x) ((x)*1000000)
+	/**
+	 * @brief Timeout in milliseconds.
+	 */
+	#define TIMEOUT_MS (500)
+	/**@}*/
+
+	/**
 	 * @name Handshake constants.
 	 */
 	/**@{*/
@@ -235,6 +249,7 @@
 	extern int ws_sendframe_txt(int fd, const char *msg, bool broadcast);
 	extern int ws_sendframe_bin(int fd, const char *msg, size_t size, bool broadcast);
 	extern int ws_get_state(int fd);
+	extern int ws_close_client(int fd);
 	extern int ws_socket(struct ws_events *evs, uint16_t port);
 
 #ifdef AFL_FUZZ

--- a/src/ws.c
+++ b/src/ws.c
@@ -151,6 +151,9 @@ static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
  *
  * @return Return the client index or -1 if invalid
  * fd.
+ *
+ * @attention This is part of the internal API and is documented just
+ * for completeness.
  */
 static int get_client_index(int fd)
 {
@@ -307,6 +310,8 @@ out:
  * @param fd File descriptor target.
  *
  * @return Pointer the ip address, or NULL if fails.
+ *
+ * @note It is up the caller to free the returned string.
  */
 char *ws_getaddress(int fd)
 {
@@ -478,6 +483,11 @@ int ws_sendframe_bin(int fd, const char *msg, size_t size, bool broadcast)
  *
  * @return Returns the connection state or -1 if
  * invalid @p fd.
+ *
+ * @see WS_STATE_CONNECTING
+ * @see WS_STATE_OPEN
+ * @see WS_STATE_CLOSING
+ * @see WS_STATE_CLOSED
  */
 int ws_get_state(int fd)
 {
@@ -542,6 +552,9 @@ int ws_close_client(int fd)
  * @param frame Frame opcode to be checked.
  *
  * @return Returns 1 if is a control frame, 0 otherwise.
+ *
+ * @attention This is part of the internal API and is documented just
+ * for completeness.
  */
 static inline int is_control_frame(int frame)
 {
@@ -616,6 +629,9 @@ static int do_handshake(struct ws_frame_data *wfd, int p_index)
  * @param close_code Websocket close code.
  *
  * @return Returns 0 if success, a negative number otherwise.
+ *
+ * @attention This is part of the internal API and is documented just
+ * for completeness.
  */
 static int do_close(struct ws_frame_data *wfd, int close_code)
 {
@@ -766,6 +782,9 @@ static int skip_frame(struct ws_frame_data *wfd, size_t frame_size)
  * @param is_fin Is FIN frame indicator.
  *
  * @return Returns 0 if success, a negative number otherwise.
+ *
+ * @attention This is part of the internal API and is documented just
+ * for completeness.
  */
 static int read_frame(struct ws_frame_data *wfd,
 	int opcode,


### PR DESCRIPTION
Description
---------------
This PR introduces support for arbitrarily closing the client connection via the function [`ws_close_client`](https://theldus.github.io/wsServer/include_2ws_8h.html#func-members). Once is invoked, the server starts the closing handshake, and if there is no response from the client for TIMEOUT_MS ms, the connection is then closed immediately.

Fixes #12 