### PR TITLE
Bug Fix: Rejects the zombie connection

### DIFF
--- a/src/ws.c
+++ b/src/ws.c
@@ -1341,12 +1341,18 @@ int ws_socket(struct ws_events *evs, uint16_t port)
 			}
 		}
 		pthread_mutex_unlock(&mutex);
-
-		if (pthread_create(&client_thread, NULL, ws_establishconnection,
+		
+		/* Client socket added to socks list ? */
+		if (i != MAX_CLIENTS)
+		{
+			if (pthread_create(&client_thread, NULL, ws_establishconnection,
 				(void *)(intptr_t)connection_index))
 			panic("Could not create the client thread!");
 
-		pthread_detach(client_thread);
+			pthread_detach(client_thread);
+		}
+		else close(new_sock);
+		
 	}
 	return (0);
 }


### PR DESCRIPTION
First of all thanks for the excellent library.

I found a situation when the socket list is full, see if it makes sense:

When the socket list is full ws_establishconnection is initialized with an invalid connection_index resulting in a zombie connection with the client.

Closing the accepted socket allows the client to manage the connection failure with the server.