### PR TITLE
Bug Fix: Ensure all bytes are sent with send()

### DIFF
--- a/include/ws.h
+++ b/include/ws.h
@@ -215,7 +215,7 @@
 
 	#ifndef AFL_FUZZ
 	#define CLI_SOCK(sock) (sock)
-	#define SEND(fd,buf,len) send((fd), (buf), (len), MSG_NOSIGNAL)
+	#define SEND(fd,buf,len) send_all((fd), (buf), (len), MSG_NOSIGNAL)
 	#define RECV(fd,buf,len) recv((fd), (buf), (len), 0)
 	#else
 	#define CLI_SOCK(sock) (fileno(stdout))

--- a/src/ws.c
+++ b/src/ws.c
@@ -144,6 +144,39 @@ static pthread_mutex_t mutex = PTHREAD_MUTEX_INITIALIZER;
 	} while (0);
 
 /**
+ * @brief Send a given message @p buf on a socket @p sockfd.
+ *
+ * @param sockfd Target socket.
+ * @param buf Message to be sent.
+ * @param len Message length.
+ * @param flags Send flags.
+ *
+ * @return Returns 0 if success (i.e: all message was sent),
+ * -1 otherwise.
+ *
+ * @note Technically this shouldn't be necessary, since send() should
+ * block until all content is sent, since _we_ don't use 'O_NONBLOCK'.
+ * However, it was reported (issue #22 on GitHub) that this was
+ * happening, so just to be cautious, I will keep using this routine.
+ */
+static ssize_t send_all(int sockfd, const void *buf, size_t len,
+	int flags)
+{
+	const char *p;
+	ssize_t ret;
+	p = buf;
+	while (len)
+	{
+		ret = send(sockfd, p, len, flags);
+		if (ret == -1)
+			return (-1);
+		p += ret;
+		len -= ret;
+	}
+	return (0);
+}
+
+/**
  * @brief For a given client @p fd, returns its
  * client index if exists, or -1 otherwise.
  *


### PR DESCRIPTION
Description
---------------
In issue #22 it was reported that the `send()` routine, when sending large amounts of data, did not send them all at once. Technically, this should not happen, since `send()` should block until all content is sent since we _not_ use `O_NONBLOCK`.

However, just to be sure of the expected behavior, this PR implements an auxiliary routine that guarantees the sending of all bytes and fails if the sending is not possible.

Thanks to @AfflatusX for the detailed investigation of the problem.

Fixes #22.