### PR TITLE
UTF-8 Support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,9 @@ add_library(ws
     src/ws.c
     src/base64/base64.c
     src/sha1/sha1.c
-    src/handshake/handshake.c)
+    src/handshake/handshake.c
+    src/utf8/utf8.c
+)
 
 if(WIN32)
 	target_link_libraries(ws pthread ws2_32 -static)
@@ -44,3 +46,8 @@ if(ENABLE_WSSERVER_TEST)
 	target_compile_definitions(send_receive PRIVATE DISABLE_VERBOSE)
 	add_subdirectory(tests)
 endif(ENABLE_WSSERVER_TEST)
+
+option(VALIDATE_UTF8 "Enable UTF-8 validation (default ON)" ON)
+if(VALIDATE_UTF8)
+	target_compile_definitions(ws PRIVATE VALIDATE_UTF8)
+endif(VALIDATE_UTF8)

--- a/Makefile
+++ b/Makefile
@@ -25,6 +25,7 @@ MCSS_DIR ?= /usr/bin/
 MANPAGES  = $(CURDIR)/doc/man/man3
 AFL_FUZZ ?= no
 VERBOSE_EXAMPLES ?= yes
+VALIDATE_UTF8 ?= yes
 
 # Prefix
 ifeq ($(PREFIX),)
@@ -47,10 +48,16 @@ ifeq ($(AFL_FUZZ), yes)
     $(info [+] AFL Fuzzing build enabled)
 endif
 
+# Check if UTF-8 validation is enabled
+ifeq ($(VALIDATE_UTF8), yes)
+	CFLAGS += -DVALIDATE_UTF8
+endif
+
 # Source
 C_SRC = $(wildcard $(SRC)/base64/*.c)    \
 		$(wildcard $(SRC)/handshake/*.c) \
 		$(wildcard $(SRC)/sha1/*.c)      \
+		$(wildcard $(SRC)/utf8/*.c)      \
 		$(wildcard $(SRC)/*.c)
 
 OBJ = $(C_SRC:.c=.o)

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ wsServer - a very tiny WebSocket server library written in C
 ## Library
 
 wsServer is a tiny, lightweight WebSocket server library written in C that intends
-to be easy to use, fast, hackable, and [almost](doc/AUTOBAHN.md) compliant to the
+to be easy to use, fast, hackable, and compliant to the
 [RFC 6455](https://tools.ietf.org/html/rfc6455).
 
 The main features are:
@@ -23,7 +23,8 @@ See Autobahn [report](https://theldus.github.io/wsServer/autobahn) and the
 
 ## Building
 
-wsServer only requires a C99-compatible compiler, such as GCC, Clang, TCC and others.
+wsServer only requires a C99-compatible compiler (such as GCC, Clang, TCC and others) and
+not external libraries.
 
 ### Make
 The preferred way to build wsServer on Linux environments:

--- a/doc/AUTOBAHN.md
+++ b/doc/AUTOBAHN.md
@@ -1,6 +1,6 @@
 # Autobahn and standard support
 Although wsServer strives to be as simple as possible, the library does intend to used
-in production and relies on two (but not limited to) tools for that: [AFL](doc/FUZZING.md)
+in production and relies on two (but not limited to) tools for that: [AFL](FUZZING.md)
 and Autobahn WebSocket Testsuite. The former ensures that wsServer is stable enough
 to be run even under unexpected conditions, such as when under attack. The latter
 is discussed below.
@@ -39,34 +39,13 @@ $ make test
 ```
 
 ## Tests results
-In order to see how well wsServer performs, the library was tested with Autobahn v0.10.9
-and the results can be seen [here](https://theldus.github.io/wsServer/autobahn).
+From the [tests](https://theldus.github.io/wsServer/autobahn), it can be seen that
+wsServer passes all Autobahn|Testsuite tests. The only tests that are not run (12.*
+and 13.*) concern WebSocket Compression, which is defined as an extension of the
+websocket protocol and defined in
+[RFC 7692](https://datatracker.ietf.org/doc/html/rfc7692). Compression does not
+belong to [RFC 6455](https://tools.ietf.org/html/rfc6455).
 
-From the tests, wsServer **do not** pass:
-- 6.3.1 to 6.3.2
-- 6.4.1 to 6.4.4
-- 6.6.1, 6.6.3, 6.6.4, 6.6.6 (ouch), 6.6.8 and 6.6.10
-- 6.8.1, 6.8.2
-- 6.10.1 to 6.10.3
-- 6.11.5
-- 6.12.1 to 6.21.8
-- 7.5.1
-
-Although it seems to be quite a lot, all of them have the very same thing in common: UTF-8
-invalid sequences validation. The specs state that if an endpoint finds an invalid UTF-8
-text sequence, it should drop the connection; wsServer in turn, does not, and this was
-intentional.
-
-wsServer intends to simple to use and to code, so I do not want to add an extra layer
-of checks in the code that just check if all UTF-8 payloads are valid or not. If this is
-a concern for your use-case, you can check if the message parameter inside the `on_message`
-event is a valid UTF-8 string or not; you can check that by using some library, such as
-[utf8.h](https://github.com/sheredom/utf8.h).
-
-Please note that wsServer is **fully** capable to send/receive UTF-8 messages it just
-does not verify if they are valid or not.
-
-## Conclusion
-wsServer is __almost__ RFC compliant and supports most of the desirable (and required) features
-in order to talk to the vast majority of clients out there. Furthermore, wsServer is
-lightweight, easy-to-use, and fast.
+Therefore, I believe it is safe to say that wsServer is RFC 6455 compliant and should
+behave correctly in different scenarios. Any unexpected behavior regarding communication
+with the client is considered an error, and an issue must be reported.

--- a/include/utf8.h
+++ b/include/utf8.h
@@ -1,0 +1,37 @@
+/**
+ * Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef UTF8_DECODE_H
+#define UTF8_DECODE_H
+
+	#include <inttypes.h>
+	#include <stddef.h>
+
+	/* UTF8 return state. */
+	#define UTF8_ACCEPT 0
+	#define UTF8_REJECT 1
+
+	extern int is_utf8(uint8_t* s);
+	extern int is_utf8_len(uint8_t *s, size_t len);
+	extern uint32_t is_utf8_len_state(uint8_t *s, size_t len, uint32_t state);
+
+#endif

--- a/include/ws.h
+++ b/include/ws.h
@@ -162,6 +162,10 @@
 	 */
 	#define WS_CLSE_PROTERR 1002
 	/**@}*/
+	/**
+	 * @brief Inconsistent message (invalid utf-8)
+	 */
+	#define WS_CLSE_INVUTF8 1007
 
 	/**
 	 * @name Connection states

--- a/src/utf8/utf8.c
+++ b/src/utf8/utf8.c
@@ -1,0 +1,88 @@
+/**
+ * Copyright (c) 2008-2009 Bjoern Hoehrmann <bjoern@hoehrmann.de>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+/*
+ * Amazing utf8 decoder & validator grabbed from:
+ *   http://bjoern.hoehrmann.de/utf-8/decoder/dfa/
+ *
+ * All rights goes to the original author.
+ */
+
+#include "utf8.h"
+
+static const uint8_t utf8d[] = {
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 20..3f
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 40..5f
+	0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 60..7f
+	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, // 80..9f
+	7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, // a0..bf
+	8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, // c0..df
+	0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3, // e0..ef
+	0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8, // f0..ff
+	0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1, // s0..s0
+	1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1, // s1..s2
+	1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1, // s3..s4
+	1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1, // s5..s6
+	1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
+};
+
+static
+uint32_t decode(uint32_t* state, uint32_t* codep, uint32_t byte) {
+	uint32_t type = utf8d[byte];
+
+	*codep = (*state != UTF8_ACCEPT) ?
+		(byte & 0x3fu) | (*codep << 6) :
+		(0xff >> type) & (byte);
+
+	*state = utf8d[256 + *state*16 + type];
+	return *state;
+}
+
+int is_utf8(uint8_t *s) {
+	uint32_t codepoint, state = 0;
+
+	while (*s)
+		decode(&state, &codepoint, *s++);
+
+	return state == UTF8_ACCEPT;
+}
+
+int is_utf8_len(uint8_t *s, size_t len) {
+	uint32_t codepoint, state = 0;
+	size_t i;
+
+	for (i = 0; i < len; i++)
+		decode(&state, &codepoint, *s++);
+
+	return state == UTF8_ACCEPT;
+}
+
+uint32_t is_utf8_len_state(uint8_t *s, size_t len, uint32_t state) {
+	uint32_t codepoint;
+	size_t i;
+
+	for (i = 0; i < len; i++)
+		decode(&state, &codepoint, *s++);
+
+	return state;
+}

--- a/tests/validate_output.py
+++ b/tests/validate_output.py
@@ -32,48 +32,6 @@ ret = 0
 # Target file
 file = "wsserver_autobahn/report/index.json"
 
-#
-# 'NOT PASSED' list
-#
-# Here we implement them as a dictionary as the lookup time
-# is so much better than an ordinary 'list'.
-#
-# Although they seem like a lot of errors, they are all related to 'invalid
-# UTF-8 sequences validation'. Since wsServer does not validate UTF-8 sequences,
-# it is natural that all tests related to this do not pass.
-#
-# However, these tests represent about ~25% (76 out of 298) of the total tests,
-# and wsServer passes everything else. Note, therefore, that wsServer is also
-# fully capable of sending and receiving UTF-8 strings, it just doesn't validate
-# them.
-#
-# More info at:
-#   https://github.com/Theldus/wsServer/blob/master/doc/AUTOBAHN.md
-#
-np_dict = {
-	"6.3.1": 1,  "6.3.2": 1,
-	"6.4.1": 1,  "6.4.2": 1, "6.4.3": 1, "6.4.4": 1,
-	"6.6.1": 1,  "6.6.3": 1, "6.6.4": 1, "6.6.6": 1, "6.6.8": 1, "6.6.10": 1,
-	"6.8.1": 1,  "6.8.2": 1,
-	"6.10.1": 1, "6.10.2": 1, "6.10.3": 1,
-	"6.11.5": 1,
-	"6.12.1": 1, "6.12.2": 1, "6.12.3": 1, "6.12.4": 1, "6.12.5": 1, "6.12.6": 1,
-	"6.12.7": 1, "6.12.8": 1,
-	"6.13.1": 1, "6.13.2": 1, "6.13.3": 1, "6.13.4": 1, "6.13.5": 1,
-	"6.14.1": 1, "6.14.2": 1, "6.14.3": 1, "6.14.4": 1, "6.14.5": 1, "6.14.6": 1,
-	"6.14.7": 1, "6.14.8": 1, "6.14.9": 1, "6.14.10": 1,
-	"6.15.1": 1,
-	"6.16.1": 1, "6.16.2": 1, "6.16.3": 1,
-	"6.17.1": 1, "6.17.2": 1, "6.17.3": 1, "6.17.4": 1, "6.17.5": 1,
-	"6.18.1": 1, "6.18.2": 1, "6.18.3": 1, "6.18.4": 1, "6.18.5": 1,
-	"6.19.1": 1, "6.19.2": 1, "6.19.3": 1, "6.19.4": 1, "6.19.5": 1,
-	"6.20.1": 1, "6.20.2": 1, "6.20.3": 1, "6.20.4": 1, "6.20.5": 1, "6.20.6": 1,
-	"6.20.7": 1,
-	"6.21.1": 1, "6.21.2": 1, "6.21.3": 1, "6.21.4": 1, "6.21.5": 1, "6.21.6": 1,
-	"6.21.7": 1, "6.21.8": 1,
-	"7.5.1": 1
-}
-
 def check_results():
 	ret = 0
 
@@ -97,9 +55,8 @@ def check_results():
 		# We must known that failure, otherwise, we're not passing the tests
 		# and we must inform the user.
 		if status == "FAILED":
-			if not test in np_dict:
-				sys.stderr.write("Test {} was not expected to fail!\n".format(test))
-				ret = 1
+			sys.stderr.write("Test {} was not expected to fail!\n".format(test))
+			ret = 1
 	return ret
 
 print("[+] Checking output...")

--- a/tests/wsserver_autobahn/fuzzingclient.json
+++ b/tests/wsserver_autobahn/fuzzingclient.json
@@ -6,6 +6,6 @@
       }
    ],
    "cases": ["*"],
-   "exclude-cases": [],
+   "exclude-cases": ["12.*", "13.*"],
    "exclude-agent-cases": {}
 }


### PR DESCRIPTION
Description
--------------
Seeking to be compliant with RFC 6455, this PR adds support for UTF-8 validation, the last hurdle that kept us from following the RFC completely (or so I hope).

Contrary to what I thought, validating text-type frames was easier than I thought, so although I was reluctant at first, there was no reason to restrict the wsServer for this feature.

However, if desired, UTF-8 validation can easily be disabled (enabled by default):
```bash
# via Makefile
$ VALIDATE_UTF8=no make

# or via CMake
$ cmake .. -DVALIDATE_UTF8=off
```