### PR TITLE
Add minimal WebSocket client support: ToyWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@
 *.a
 send_receive
 ws_file
+toyws_test
 build/
 doc/doxygen/html
 doc/doxygen/xml

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,6 +43,10 @@ add_executable(toyws_test
     extra/toyws/tws_test.c
     extra/toyws/toyws.c)
 
+if(WIN32)
+    target_link_libraries(toyws_test ws2_32 -static)
+endif(WIN32)
+
 option(ENABLE_WSSERVER_TEST "Enable wsServer testing (requires Autobahn)" OFF)
 if(ENABLE_WSSERVER_TEST)
 	enable_testing()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,6 +39,10 @@ add_executable(send_receive
     example/send_receive.c)
 target_link_libraries(send_receive ws)
 
+add_executable(toyws_test
+    extra/toyws/tws_test.c
+    extra/toyws/toyws.c)
+
 option(ENABLE_WSSERVER_TEST "Enable wsServer testing (requires Autobahn)" OFF)
 if(ENABLE_WSSERVER_TEST)
 	enable_testing()

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,9 @@ BINDIR = $(PREFIX)/bin
 MANDIR = $(PREFIX)/man
 PKGDIR = $(LIBDIR)/pkgconfig
 
+# Extra paths
+TOYWS  = $(CURDIR)/extra/toyws
+
 # General objects
 %.o: %.c
 	$(CC) $< $(CFLAGS) -c -o $@
@@ -99,6 +102,10 @@ tests_check:
 # Fuzzing tests
 fuzzy: libws.a
 	$(MAKE) -C tests/fuzzy
+
+# ToyWS client
+toyws_test: $(TOYWS)/tws_test.o $(TOYWS)/toyws.o
+	$(CC) $^ $(CFLAGS) -I $(TOYWS) -o $@
 
 # Install rules
 install: libws.a wsserver.pc
@@ -156,6 +163,7 @@ doc:
 clean:
 	@rm -f $(OBJ)
 	@rm -f $(LIB)
+	@rm -f $(TOYWS)/toyws.o $(TOYWS)/tws_test.o toyws_test
 	@$(MAKE) clean -C example/
 	@$(MAKE) clean -C tests/
 	@$(MAKE) clean -C tests/fuzzy

--- a/README.md
+++ b/README.md
@@ -160,6 +160,17 @@ int main()
 
 to build the example above, just invoke: `make examples`.
 
+## WebSocket client: ToyWS
+Inside `extra/toyws` there is a companion project called ToyWS. ToyWS is a very
+simple & dumb WebSocket client made exclusively to work with wsServer. Extremely
+limited, its usage is highly discouraged with other servers other than wsServer
+and is only meant to be used in conjunction with wsServer.
+
+This mini-project only serves as an aid to wsServer and frees the user from
+using additional projects to use wsServer in its entirety.
+
+More info at: [extra/toyws/README.md](extra/toyws/README.md)
+
 ## SSL/TLS Support
 wsServer does not currently support encryption. However, it is possible to use it
 in conjunction with [Stunnel](https://www.stunnel.org/), a proxy that adds TLS

--- a/extra/toyws/README.md
+++ b/extra/toyws/README.md
@@ -1,0 +1,145 @@
+# ToyWS
+Since there is some demand to support a client, 'ToyWS' is a response to those
+requests: ToyWS is a toy WebSocket client, meaning that it's quite simple and
+made to work (guaranteed) only with wsServer.
+
+Limitations:
+ - Fixed handshake header
+ - Fixed frame mask (it should be random)
+ - No PING/PONG frame support
+ - No close handshake support: although it can identify CLOSE frames, it
+   does not send the response, only aborts the connection.
+ - No support for CONT frames, that is, the entire content of a frame (TXT
+   or BIN) must be contained within a single frame.
+ - Possibly other things too.
+
+Although extremely limited, ToyWS was designed for those who want to _also_
+have a C client that is lightweight and compatible with wsServer, thus,
+freeing the need for a browser and/or third-party libraries to test and use
+wsServer.
+
+Maybe this client will evolve into something more complete and general in the
+future, but that's not in the roadmap at the moment.
+
+## API
+The API is quite simple and is summarized in 4 routines, to connect,
+disconnect, send and receive frame, as follows:
+
+```c
+int tws_connect(struct tws_ctx *ctx, const char *ip, uint16_t port);
+```
+Connect to a given `ip` address and `port`.
+
+**Return**:
+Returns a positive number if success, otherwise, a negative number.
+
+**Note:**
+`struct tws_ctx *ctx` is for internal usage and initialized within this
+function. There is no need to access this structure or modify its values, ToyWS
+just needs it to maintain the consistent client state.
+
+---
+
+```c
+void tws_close(struct tws_ctx *ctx);
+```
+Close the connection for the given `ctx`.
+
+---
+
+```c
+int tws_sendframe(struct tws_ctx *ctx, uint8_t *msg, uint64_t size, int type);
+```
+Send a frame of type `type` with content `msg` and size `size` for a given
+context `ctx`.
+
+Valid frame types are:
+- FRM_TXT
+- FRM_BIN
+
+**Return**:
+Returns 0 if success, otherwise, a negative number.
+
+---
+
+```c
+int tws_receiveframe(struct tws_ctx *ctx, char **buff, size_t *buff_size,
+    int *frm_type);
+```
+Receive a frame and save it on `buff`.
+
+**Parameters:**
+
+**`buff`:**
+
+Pointer to the target buffer. If NULL, ToyWS will allocate a new buffer that is
+capable to hold the frame and save into `buff`.
+
+If already exists: the function will try to fill the buffer with the frame
+content, if the frame size is bigger than `buff_size`, the function will
+reallocate `buff` and update `buff_size` with the new size.
+
+**`buff_size`:**
+
+Current buffer size. __Must__ point the a valid memory region. If `*buff`
+points to NULL, `*buff_size` must be equals to 0.
+
+**`frm_type`:**
+
+Frame type read. The frame type received will be reflected into the contents of
+this pointer.
+
+**Return**: Returns 0 if success, a negative number otherwise.
+
+**Note**:
+
+- This routine is blocking, that is, it will only return if it manages to read
+a frame or if there is an error during the reading (such as invalid (or
+unsupported) frame or server disconnection).
+
+- At the end of everything, don't forget to free the buffer!. Once its size is
+relocated, a single call to 'free' is sufficient.
+
+## Example
+The example below illustrates the usage (also available at (extra/toyws/tws_test.c)):
+```c
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "toyws.h"
+
+int main(void)
+{
+    struct tws_ctx ctx;
+    char msg[] = "Hello";
+
+    /* Buffer/frame params. */
+    char *buff;
+    int frm_type;
+    size_t buff_size;
+
+    buff      = NULL;
+    buff_size = 0;
+    frm_type  = 0;
+
+    if (tws_connect(&ctx, "127.0.0.1", 8080) < 0)
+        fprintf(stderr, "Unable to connect!\n");
+
+    /* Send message. */
+    printf("Send: %s\n",
+        (tws_sendframe(&ctx, msg, strlen(msg), FRM_TXT) >= 0 ?
+            "Success" : "Failed"));
+
+    /* Blocks until receive a single message. */
+    if (tws_receiveframe(&ctx, &buff, &buff_size, &frm_type) < 0)
+        fprintf(stderr, "Unable to receive message!\n");
+
+    printf("I received: (%s) (type: %s)\n", buff,
+        (frm_type == FRM_TXT ? "Text" : "Binary"));
+
+    tws_close(&ctx);
+
+    free(buff);
+    return (0);
+}
+```

--- a/extra/toyws/toyws.c
+++ b/extra/toyws/toyws.c
@@ -1,0 +1,372 @@
+/*
+ * Copyright (C) 2022  Davidson Francis <davidsondfgl@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <stddef.h>
+#include <inttypes.h>
+#include <unistd.h>
+
+#include <arpa/inet.h>
+#include <sys/socket.h>
+#include <netinet/in.h>
+
+#include "toyws.h"
+
+/*
+ * This is a WebSocket 'toy client', made exclusively to work with wsServer.
+ *
+ * Although it is independent of the wsServer src tree, it is highly limited
+ * and therefore not recommended for use with other servers.
+ *
+ * There are the following restrictions (not limited to):
+ * - Fixed handshake header
+ *
+ * - Fixed frame mask (ideally it should be random)
+ *
+ * - No PING/PONG frame support
+ *
+ * - No close handshake support: although it can identify CLOSE frames, it
+ *   does not send the response, it just aborts the connection.
+ *
+ * - No support for CONT frames, that is, the entire content of a frame (TXT
+ *   or BIN) must be contained in a single message.
+ *
+ * - Possibly other things too.
+ *
+ * Other than that, this client supports sending and receiving frames and
+ * should work 'ok' with wsServer. Since there was some demand for client
+ * support, this mini-project is a response to those requests =).
+*/
+
+/* Dummy/constant request. */
+static const char request[] =
+	"GET / HTTP/1.1\r\n"
+	"Host: localhost:8080\r\n"
+	"Connection: Upgrade\r\n"
+	"Upgrade: websocket\r\n"
+	"Sec-WebSocket-Version: 13\r\n"
+	"Sec-WebSocket-Key: uaGPoPbZRzHcWDXiNQ5dyg==\r\n\r\n";
+
+/**
+ * @brief Connect to a given @p ip address and @p port.
+ *
+ * @param ctx WebSocket client context.
+ * @param ip Target IP address to connect.
+ * @param port Server port.
+ *
+ * @return Returns the socket fd if success, otherwise, returns
+ * a negative number.
+ */
+int tws_connect(struct tws_ctx *ctx, const char *ip, uint16_t port)
+{
+	char *p;
+	int sock;
+	ssize_t ret;
+	in_addr_t ip_addr;
+	struct sockaddr_in s_addr;
+
+	memset(ctx, 0, sizeof(*ctx));
+
+	/* Create socket. */
+	sock = socket(AF_INET, SOCK_STREAM, 0);
+	if (sock < 0)
+		return (-1);
+
+	memset((void*)&s_addr, 0, sizeof(s_addr));
+	s_addr.sin_family = AF_INET;
+
+	if ((ip_addr = inet_addr(ip)) == INADDR_NONE)
+		return (-1);
+
+	s_addr.sin_addr.s_addr = ip_addr;
+	s_addr.sin_port = htons(port);
+
+	/* Connect. */
+	if (connect(sock, (struct sockaddr *)&s_addr, sizeof(s_addr)) < 0)
+		return (-1);
+
+	/* Do handhshake. */
+	if (send(sock, request, strlen(request), MSG_NOSIGNAL) < 0)
+		return (-1);
+
+	/* Wait for 'switching protocols'. */
+	if ((ret = recv(sock, ctx->frm, sizeof(ctx->frm), 0)) < 0)
+		return (-1);
+
+	/* Advance our pointers before the first next_byte(). */
+	p = strstr((const char *)ctx->frm, "\r\n\r\n");
+	ctx->amt_read = ret;
+	ctx->cur_pos  = (size_t)((ptrdiff_t)(p - (char *)ctx->frm)) + 4;
+	ctx->fd       = sock;
+	ctx->status   = ST_CONNECTED;
+
+	return (sock);
+}
+
+/**
+ * @brief Close the connection for the given @p ctx.
+ *
+ * @param ctx WebSocket client context.
+ */
+void tws_close(struct tws_ctx *ctx)
+{
+	if (ctx->status == ST_DISCONNECTED)
+		return;
+	shutdown(ctx->fd, SHUT_RDWR);
+	close(ctx->fd);
+	ctx->status = ST_DISCONNECTED;
+}
+
+/**
+ * @brief Send a frame of type @p type with content @p msg and
+ * size @p size for a given context @p ctx.
+ *
+ * @param ctx WebSocket client context.
+ * @param msg Frame message.
+ * @param size Frame size.
+ * @param type Frame type (e.g: FRM_TXT, FRM_BIN...)
+ *
+ * @return Returns 0 if success, a negative number otherwise.
+ */
+int tws_sendframe(struct tws_ctx *ctx, uint8_t *msg, uint64_t size,
+	int type)
+{
+	uint8_t frame[10] = {0};
+	uint8_t masks[4];
+	uint64_t length;
+	uint8_t hdr_len;
+	size_t count;
+	uint8_t *tmp;
+	uint8_t *p;
+
+	frame[0]  = FRM_FIN | type;
+	frame[1] |= FRM_MSK;
+	length	  = (uint64_t)size;
+
+	/* Split the size between octets. */
+	if (length <= 125)
+	{
+		frame[1] |= length & 0x7F;
+		hdr_len = 2;
+	}
+
+	/* Size between 126 and 65535 bytes. */
+	else if (length >= 126 && length <= 65535)
+	{
+		frame[1] |= 126;
+		frame[2]  = (length >> 8) & 255;
+		frame[3]  = length & 255;
+		hdr_len = 4;
+	}
+
+	/* More than 65535 bytes. */
+	else
+	{
+		frame[1] |= 127;
+		frame[2]  = (uint8_t)((length >> 56) & 255);
+		frame[3]  = (uint8_t)((length >> 48) & 255);
+		frame[4]  = (uint8_t)((length >> 40) & 255);
+		frame[5]  = (uint8_t)((length >> 32) & 255);
+		frame[6]  = (uint8_t)((length >> 24) & 255);
+		frame[7]  = (uint8_t)((length >> 16) & 255);
+		frame[8]  = (uint8_t)((length >> 8) & 255);
+		frame[9]  = (uint8_t)(length & 255);
+		hdr_len = 10;
+	}
+
+	/* Send header. */
+	if (send(ctx->fd, frame, hdr_len, MSG_NOSIGNAL) < 0)
+		return (-1);
+
+	/* Send dummy masks. */
+	masks[0] = masks[1] = masks[2] = masks[3] = 0xAA;
+	if (send(ctx->fd, masks, 4, MSG_NOSIGNAL) < 0)
+		return (-2);
+
+	/* Mask message and send it. */
+	p = calloc(1, size);
+	if (!p)
+		return (-3);
+
+	memcpy(p, msg, size);
+
+	for (tmp = p, count = 0; count < size; tmp++, count++)
+		*tmp ^= masks[count % 4];
+
+	if (send(ctx->fd, p, size, MSG_NOSIGNAL) < 0)
+	{
+		free(p);
+		return (-4);
+	}
+
+	free(p);
+	return (0);
+}
+
+/**
+ * @brief Read a chunk of bytes and return the next byte
+ * belonging to the frame.
+ *
+ * @param ctx Websocket Context.
+ * @param ret Optional return code.
+ *
+ * @return Returns the byte read, or -1 if error.
+ */
+static inline int next_byte(struct tws_ctx *ctx, int *ret)
+{
+	ssize_t n;
+
+	/* If empty or full. */
+	if (ctx->cur_pos == 0 || ctx->cur_pos == ctx->amt_read)
+	{
+		if ((n = recv(ctx->fd, ctx->frm, sizeof(ctx->frm), 0)) <= 0)
+		{
+			if (ret)
+				*ret = 1;
+			return (-1);
+		}
+
+		ctx->amt_read = (size_t)n;
+		ctx->cur_pos  = 0;
+	}
+	return (ctx->frm[ctx->cur_pos++]);
+}
+
+/**
+ * @brief Skips @p frame_size bytes of the current frame.
+ *
+ * @param ctx Websocket Context.
+ * @param frame_size Amount of bytes to be skipped.
+ *
+ * @return Returns 0 if success, a negative number
+ * otherwise.
+ */
+static int skip_frame(struct tws_ctx *ctx, uint64_t frame_size)
+{
+	uint64_t i;
+	for (i = 0; i < frame_size; i++)
+		if (next_byte(ctx, NULL) == -1)
+			return (-1);
+	return (0);
+}
+
+/**
+ * @brief Receive a frame and save it on @p buff.
+ *
+ * If @p buff is NULL, this function will allocate a new
+ * buffer and save the new size in @p buff_size. If not
+ * NULL and if @p buff_size is greater than the frame,
+ * the buffer is used, otherwise, the address will be
+ * reallocated.
+ *
+ * @param ctx WebSocket Context.
+ * @param buff Buffer pointer.
+ * @param buff_size Buffer size.
+ * @param frm_type Frame type received.
+ *
+ * @return Returns 0 if success, a negative number
+ * otherwise.
+ */
+int tws_receiveframe(struct tws_ctx *ctx, char **buff,
+	size_t *buff_size, int *frm_type)
+{
+	int ret;
+	char *buf;
+	uint64_t i;
+	int cur_byte;
+	uint8_t opcode;
+	uint64_t frame_length;
+
+	/* Buffer should be valid. */
+	if (!buff || (*buff && !buff_size))
+		return (-1);
+
+	ret = 0;
+	cur_byte = next_byte(ctx, &ret);
+	opcode = (cur_byte & 0xF);
+
+	/* If CLOSE, lets close, abruptly, because why not?. */
+	if (opcode == FRM_CLSE)
+	{
+		tws_close(ctx);
+		return (-1);
+	}
+
+	frame_length = next_byte(ctx, &ret) & 0x7F;
+
+	/* Read remaining length bytes, if any. */
+	if (frame_length == 126)
+	{
+		frame_length = (((uint64_t)next_byte(ctx, &ret)) << 8) |
+			next_byte(ctx, &ret);
+	}
+
+	else if (frame_length == 127)
+	{
+		frame_length =
+			(((uint64_t)next_byte(ctx, &ret)) << 56) | /* frame[2]. */
+			(((uint64_t)next_byte(ctx, &ret)) << 48) | /* frame[3]. */
+			(((uint64_t)next_byte(ctx, &ret)) << 40) |
+			(((uint64_t)next_byte(ctx, &ret)) << 32) |
+			(((uint64_t)next_byte(ctx, &ret)) << 24) |
+			(((uint64_t)next_byte(ctx, &ret)) << 16) |
+			(((uint64_t)next_byte(ctx, &ret)) <<  8) |
+			(((uint64_t)next_byte(ctx, &ret))); /* frame[9]. */
+	}
+
+	/* Check if any error before proceed. */
+	if (ret)
+		return (ret);
+
+	/*
+	 * If frame is something other than CLSE and TXT/BIN (like PONG
+	 * or CONT), skip.
+	 */
+	if (opcode != FRM_TXT && opcode != FRM_BIN)
+		if (skip_frame(ctx, frame_length) < 0)
+			return (-1);
+
+	/* Allocate memory, if needed. */
+	if (*buff_size < frame_length)
+	{
+		buf = realloc(*buff, frame_length + 1);
+		if (!buf)
+			return (-1);
+		*buff = buf;
+		*buff_size = frame_length + 1;
+	}
+	else
+		buf = *buff;
+
+	/* Receive frame. */
+	for (i = 0; i < frame_length; i++, buf++)
+	{
+		cur_byte = next_byte(ctx, &ret);
+		if (cur_byte < 0)
+			return (ret);
+
+		*buf = cur_byte;
+	}
+	*buf = '\0';
+
+	/* Fill other infos. */
+	*frm_type = opcode;
+
+	return (ret);
+}

--- a/extra/toyws/toyws.h
+++ b/extra/toyws/toyws.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2022  Davidson Francis <davidsondfgl@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>
+ */
+
+#ifndef TOYWS_H
+#define TOYWS_H
+
+	#include <stdint.h>
+
+	/* Frame constants. */
+	#define FRM_TXT  1
+	#define FRM_BIN  2
+	#define FRM_CLSE 8
+	#define FRM_FIN 128
+	#define FRM_MSK 128
+
+	#define MESSAGE_LENGTH 1024
+
+	/* Client status. */
+	#define ST_DISCONNECTED 0
+	#define ST_CONNECTED    1
+
+	/* Client context. */
+	struct tws_ctx
+	{
+		uint8_t frm[MESSAGE_LENGTH];
+		size_t amt_read;
+		size_t cur_pos;
+		int status;
+		int fd;
+	};
+
+	/* External functions. */
+	extern int tws_connect(struct tws_ctx *ctx, const char *ip,
+		uint16_t port);
+	extern void tws_close(struct tws_ctx *ctx);
+	extern int tws_sendframe(struct tws_ctx *ctx, uint8_t *msg,
+		uint64_t size, int type);
+	extern int tws_receiveframe(struct tws_ctx *ctx, char **buff,
+		size_t *buff_size, int *frm_type);
+
+#endif /* TOYWS_H */

--- a/extra/toyws/toyws.h
+++ b/extra/toyws/toyws.h
@@ -30,8 +30,8 @@
 	#define MESSAGE_LENGTH 1024
 
 	/* Client status. */
-	#define ST_DISCONNECTED 0
-	#define ST_CONNECTED    1
+	#define TWS_ST_DISCONNECTED 0
+	#define TWS_ST_CONNECTED    1
 
 	/* Client context. */
 	struct tws_ctx

--- a/extra/toyws/tws_test.c
+++ b/extra/toyws/tws_test.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2022  Davidson Francis <davidsondfgl@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.	 If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "toyws.h"
+
+int main(void)
+{
+	struct tws_ctx ctx;
+	char msg[] = "Hello";
+
+	/* Buffer params. */
+	char *buff;
+	int frm_type;
+	size_t buff_size;
+
+	buff      = NULL;
+	buff_size = 0;
+	frm_type  = 0;
+
+	if (tws_connect(&ctx, "127.0.0.1", 8080) < 0)
+		fprintf(stderr, "Unable to connect!\n");
+
+	/* Send message. */
+	printf("Send: %s\n",
+		(tws_sendframe(&ctx, (uint8_t*)msg, strlen(msg), FRM_TXT) >= 0 ?
+			"Success" : "Failed"));
+
+	/* Blocks until receive a single message. */
+	if (tws_receiveframe(&ctx, &buff, &buff_size, &frm_type) < 0)
+		fprintf(stderr, "Unable to receive message!\n");
+
+	printf("I received: (%s) (type: %s)\n", buff,
+		(frm_type == FRM_TXT ? "Text" : "Binary"));
+
+	tws_close(&ctx);
+
+	free(buff);
+	return (0);
+}


### PR DESCRIPTION
Description
--------------
Since there is some demand (#41, #38, #35) to support a client, 'ToyWS' is a response to those requests: ToyWS is a toy WebSocket client, meaning that it's quite simple and made to work (guaranteed) _only_ with wsServer.

Limitations:
- Fixed handshake header
- Fixed frame mask (it should be random)
- No PING/PONG frame support
- No close handshake support: although it can identify CLOSE frames, it does not send the response, only aborts the connection.
- No support for CONT frames, that is, the entire content of a frame (TXT or BIN) must be contained within a single frame.
- Possibly other things too.

Although extremely limited, ToyWS was designed for those who want to also have a C client that is lightweight and compatible with wsServer, thus, freeing the need for a browser and/or third-party libraries to test and use wsServer.

Maybe this client will evolve into something more complete and general in the future, but that's not in the roadmap at the moment.

**Note**: Please avoid using ToyWS on servers other than wsServer as it is quite limited (see above) and may not support the variety of servers out there.