### PR TITLE
change wfd->sock to wfd->client->client_sock

### DIFF
--- a/src/ws.c
+++ b/src/ws.c
@@ -939,7 +939,7 @@ static int read_frame(struct ws_frame_data *wfd,
 	{
 		DEBUG("Current frame from client %d, exceeds the maximum\n"
 			  "amount of bytes allowed (%" PRId64 "/%d)!",
-			wfd->sock, *frame_size + *frame_length, MAX_FRAME_LENGTH);
+			wfd->client->client_sock, *frame_size + *frame_length, MAX_FRAME_LENGTH);
 
 		wfd->error = 1;
 		return (-1);


### PR DESCRIPTION
If you define the macro VERBOSE_MODE to activate the DEBUG output, you will get the error message
wsServer/src/ws.c:942:28: Error: »struct ws_frame_data« has no element with the name »sock«

This request fixes the error