### PR TITLE
Ping/Pong v2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,6 @@
 # Ignore object files, executables and the library.
 *.o
 *.a
-send_receive
 ws_file
 toyws_test
 build/
@@ -24,3 +23,5 @@ doc/doxygen/html
 doc/doxygen/xml
 tests/wsserver_autobahn/report
 tests/fuzzy/out/
+examples/echo/echo
+examples/ping/ping

--- a/doc/man/man3/ws_ping.3
+++ b/doc/man/man3/ws_ping.3
@@ -1,0 +1,44 @@
+.\"
+.\" Copyright (C) 2022  Davidson Francis <davidsondfgl@gmail.com>
+.\"
+.\" This program is free software: you can redistribute it and/or modify
+.\" it under the terms of the GNU General Public License as published by
+.\" the Free Software Foundation, either version 3 of the License, or
+.\" (at your option) any later version.
+.\"
+.\" This program is distributed in the hope that it will be useful,
+.\" but WITHOUT ANY WARRANTY; without even the implied warranty of
+.\" MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+.\" GNU General Public License for more details.
+.\"
+.\" You should have received a copy of the GNU General Public License
+.\" along with this program.  If not, see <http://www.gnu.org/licenses/>
+.\"
+.TH man 3 "29 Apr 2022" "1.0" "wsServer man page"
+.SH NAME
+ws_ping \- Sends a ping to a single client or broadcast
+.SH SYNOPSIS
+.nf
+.B #include <ws.h>
+.sp
+.BI "void ws_ping(ws_cli_conn_t " *client ", int " broadcast ");"
+.fi
+.SH DESCRIPTION
+.BR ws_ping ()
+sends a ping message to the
+.I client
+(or broadcast if NULL) with a given
+.I threshold.
+Although wsServer supports sending PINGs, they are not automatic: the user
+needs to invoke
+.BR ws_ping()
+periodically, whether in a separate thread (recommended) or not.
+
+The interval between each call determines the 'timeout' between PINGs.
+
+Threshold must be positive and greater than zero, and determines how many
+PINGs can be ignored.
+.SH RETURN VALUE
+The function does not return any value.
+.SH AUTHOR
+Davidson Francis (davidsondfgl@gmail.com)

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -16,12 +16,17 @@
 .PHONY: all clean
 
 # Examples
-all: echo/echo
+all: echo/echo ping/ping
 
 # Echo
 echo/echo:
 	$(MAKE) -C echo/ all
 
+# Ping
+ping/ping:
+	$(MAKE) -C ping/ all
+
 # Clean
 clean:
 	$(MAKE) -C echo/ clean
+	$(MAKE) -C ping/ clean

--- a/examples/ping/CMakeLists.txt
+++ b/examples/ping/CMakeLists.txt
@@ -13,6 +13,5 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-add_subdirectory(echo)
-add_subdirectory(ping)
-add_subdirectory(vtouchpad)
+add_executable(ping ping.c)
+target_link_libraries(ping ws)

--- a/examples/ping/Makefile
+++ b/examples/ping/Makefile
@@ -1,4 +1,4 @@
-# Copyright (C) 2022  Davidson Francis <davidsondfgl@gmail.com>
+# Copyright (C) 2022 Davidson Francis <davidsondfgl@gmail.com>
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -13,6 +13,27 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>
 
-add_subdirectory(echo)
-add_subdirectory(ping)
-add_subdirectory(vtouchpad)
+CC      ?= gcc
+WSDIR    = $(CURDIR)/../../
+INCLUDE  = -I $(WSDIR)/include
+CFLAGS   =  -Wall -Wextra -O2
+CFLAGS  +=  $(INCLUDE) -std=c99 -pthread -pedantic
+LDLIBS  +=  $(WSDIR)/libws.a
+TARGET   =  ping
+
+.PHONY: all clean
+
+# Build objects rule
+%.o: %.c
+	$(CC) $< $(CFLAGS) $(INCLUDE) -c -o $@
+
+all: $(TARGET)
+
+# Ping
+$(TARGET): $(TARGET).o $(LDLIBS)
+	$(CC) $(CFLAGS) $(LDFLAGS) $^ -o $@ $(LDLIBS)
+
+# Clean
+clean:
+	@rm -f $(TARGET)
+	@rm -f *.o

--- a/examples/ping/ping.c
+++ b/examples/ping/ping.c
@@ -1,0 +1,104 @@
+/*
+ * Copyright (C) 2022 Davidson Francis <davidsondfgl@gmail.com>
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <ws.h>
+
+/**
+ * @dir examples/ping
+ * @brief Ping example directory
+ *
+ * @file ping.c
+ * @brief Main file.
+ */
+
+/**
+ * @brief Called when a client connects to the server.
+ *
+ * @param client Client connection.
+ */
+void onopen(ws_cli_conn_t *client)
+{
+	((void)client);
+	printf("Connected!\n");
+}
+
+/**
+ * @brief Called when a client disconnects to the server.
+ *
+ * @param client Client connection.
+ */
+void onclose(ws_cli_conn_t *client)
+{
+	((void)client);
+	printf("Disconnected!\n");
+}
+
+/**
+ * @brief Called when a client connects to the server.
+ *
+ * @param client Client connection.
+ *
+ * @param msg Received message.
+ * @param size Message size (in bytes).
+ * @param type Message type.
+ */
+void onmessage(ws_cli_conn_t *client,
+	const unsigned char *msg, uint64_t size, int type)
+{
+	((void)client);
+	((void)msg);
+	((void)size);
+	((void)type);
+}
+
+/**
+ * @brief Main routine.
+ */
+int main(void)
+{
+	struct ws_events evs;
+	evs.onopen    = &onopen;
+	evs.onclose   = &onclose;
+	evs.onmessage = &onmessage;
+	ws_socket(&evs, 8080, 1);
+
+	/*
+	 * Periodically send ping frames in the main thread
+	 * and aborts inactive connections.
+	 */
+	while (1)
+	{
+		/*
+		 * Sends a broadcast PING with 2-DELAY MS of tolerance, i.e:
+		 * the client can miss up to 2 PINGs messages.
+		 *
+		 * The 'timeout' is specified by the time between ws_ping()
+		 * calls. In this example, 10 seconds.
+		 */
+		printf("Sending ping...\n");
+		ws_ping(NULL, 2);
+
+		/* Sleep 10 seconds. */
+		sleep(10);
+	}
+
+	return (0);
+}

--- a/include/ws.h
+++ b/include/ws.h
@@ -266,7 +266,8 @@ extern "C" {
 	extern int ws_close_client(ws_cli_conn_t *cli);
 	extern int ws_socket(struct ws_events *evs, uint16_t port, int thread_loop);
 
-	extern long int ws_ping(ws_cli_conn_t *cli, long int ws_ping_id);
+	/* Ping routines. */
+	extern void ws_ping(ws_cli_conn_t *cli, int threshold);
 
 #ifdef AFL_FUZZ
 	extern int ws_file(struct ws_events *evs, const char *file);


### PR DESCRIPTION
Description
-----------
In PR #51 an early version of Ping/Pong was introduced by @gloveboxes.

As discussed earlier in issue #50, some modifications would be made for a final version of wsServer PING support. This PR addresses those changes.

This 'v2' changes:
- Removal of using snprintf/strtol to send the PING id as a string: the PING id is now sent as a number, always encoded as a big-endian 32-bit signed integer. This brings an interesting advantage:
  
   - [RFC 6455](https://datatracker.ietf.org/doc/html/rfc6455#section-5.5.3) specifies that an unsolicited PONG frame can be sent, as a unidirectional heartbeat: sending a non-fixed-length string makes it difficult to know whether the received PONG was in response to a PING or not. On the other hand, sending a number with known encoding and size makes it easier to know if the PONG received is in response to a PING or not, either by the size (always 4 bytes), or by the content itself.

- Use of locks for reading/writing the PING and PONG id, since there may be race conditions between receiving a PONG and sending a PING.

- Sending pings to a client or broadcast: the 'client' parameter defines this. In addition, PING and PONG id is now managed by the server itself, which maintains a private copy for each connected client. This also allows the broadcast to send different IDs accordingly to the client counter itself.

Also, this PR adds a man page (doc/man/man3/ws_ping.3) and an example file, located at examples/ping.

---

@gloveboxes This PR basically brings together everything we talked about earlier and that's what I can imagine for the final version. Since the initial idea was yours, I would like to hear from you: what do you think? is there anything that could be improved/removed/etc or it seems ok to you?

Hope this eases your problem with clients disconnecting while sleeping =).
Again, thank you very much for your contribution.