### PR TITLE
ability to specify binding host, vague ipv6 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,10 +145,10 @@ int main(void)
     /*
      * Main loop, this function never* returns.
      *
-     * *If the third argument is != 0, a new thread is created
+     * *If the fourth argument is != 0, a new thread is created
      * to handle new connections.
      */
-    ws_socket(&evs, 8080, 0, 1000);
+    ws_socket(&evs, NULL, "8080", 0, 1000);
 
     return (0);
 }

--- a/examples/echo/echo.c
+++ b/examples/echo/echo.c
@@ -117,7 +117,7 @@ int main(void)
 	evs.onopen    = &onopen;
 	evs.onclose   = &onclose;
 	evs.onmessage = &onmessage;
-	ws_socket(&evs, "::1", "8080", 0, 1000); /* Never returns. */
+	ws_socket(&evs, NULL, "8080", 0, 1000); /* Never returns. */
 
 	/*
 	 * If you want to execute code past ws_socket, invoke it like:

--- a/examples/echo/echo.c
+++ b/examples/echo/echo.c
@@ -42,10 +42,11 @@
  */
 void onopen(ws_cli_conn_t *client)
 {
-	char *cli;
+	char *cli, *port;
 	cli = ws_getaddress(client);
+	port = ws_getport(client);
 #ifndef DISABLE_VERBOSE
-	printf("Connection opened, addr: %s\n", cli);
+	printf("Connection opened, addr: %s port %s\n", cli, port);
 #endif
 }
 
@@ -58,10 +59,11 @@ void onopen(ws_cli_conn_t *client)
  */
 void onclose(ws_cli_conn_t *client)
 {
-	char *cli;
+	char *cli, *port;
 	cli = ws_getaddress(client);
+	port = ws_getport(client);
 #ifndef DISABLE_VERBOSE
-	printf("Connection closed, addr: %s\n", cli);
+	printf("Connection closed, addr: %s port %s\n", cli, port);
 #endif
 }
 
@@ -82,11 +84,12 @@ void onclose(ws_cli_conn_t *client)
 void onmessage(ws_cli_conn_t *client,
 	const unsigned char *msg, uint64_t size, int type)
 {
-	char *cli;
+	char *cli, *port;
 	cli = ws_getaddress(client);
+	port = ws_getport(client);
 #ifndef DISABLE_VERBOSE
-	printf("I receive a message: %s (size: %" PRId64 ", type: %d), from: %s\n",
-		msg, size, type, cli);
+	printf("I receive a message: %s (size: %" PRId64 ", type: %d), from: %s port %s\n",
+		msg, size, type, cli, port);
 #endif
 
 	/**
@@ -114,7 +117,7 @@ int main(void)
 	evs.onopen    = &onopen;
 	evs.onclose   = &onclose;
 	evs.onmessage = &onmessage;
-	ws_socket(&evs, NULL, 8080, 0, 1000); /* Never returns. */
+	ws_socket(&evs, "::1", "8080", 0, 1000); /* Never returns. */
 
 	/*
 	 * If you want to execute code past ws_socket, invoke it like:

--- a/examples/echo/echo.c
+++ b/examples/echo/echo.c
@@ -114,7 +114,7 @@ int main(void)
 	evs.onopen    = &onopen;
 	evs.onclose   = &onclose;
 	evs.onmessage = &onmessage;
-	ws_socket(&evs, 8080, 0, 1000); /* Never returns. */
+	ws_socket(&evs, NULL, 8080, 0, 1000); /* Never returns. */
 
 	/*
 	 * If you want to execute code past ws_socket, invoke it like:

--- a/examples/ping/ping.c
+++ b/examples/ping/ping.c
@@ -78,7 +78,7 @@ int main(void)
 	evs.onopen    = &onopen;
 	evs.onclose   = &onclose;
 	evs.onmessage = &onmessage;
-	ws_socket(&evs, NULL, 8080, 1, 1000);
+	ws_socket(&evs, NULL, "8080", 1, 1000);
 
 	/*
 	 * Periodically send ping frames in the main thread

--- a/examples/ping/ping.c
+++ b/examples/ping/ping.c
@@ -78,7 +78,7 @@ int main(void)
 	evs.onopen    = &onopen;
 	evs.onclose   = &onclose;
 	evs.onmessage = &onmessage;
-	ws_socket(&evs, 8080, 1, 1000);
+	ws_socket(&evs, NULL, 8080, 1, 1000);
 
 	/*
 	 * Periodically send ping frames in the main thread

--- a/examples/vtouchpad/vtouchpad.c
+++ b/examples/vtouchpad/vtouchpad.c
@@ -202,7 +202,7 @@ int main(void)
 	/* Mouse. */
 	mouse = mouse_new();
 
-	ws_socket(&evs, 8080, 0, 1000);
+	ws_socket(&evs, NULL, 8080, 0, 1000);
 
 	mouse_free(mouse);
 

--- a/examples/vtouchpad/vtouchpad.c
+++ b/examples/vtouchpad/vtouchpad.c
@@ -202,7 +202,7 @@ int main(void)
 	/* Mouse. */
 	mouse = mouse_new();
 
-	ws_socket(&evs, NULL, 8080, 0, 1000);
+	ws_socket(&evs, NULL, "8080", 0, 1000);
 
 	mouse_free(mouse);
 

--- a/include/ws.h
+++ b/include/ws.h
@@ -258,13 +258,15 @@ extern "C" {
 
 	/* External usage. */
 	extern char *ws_getaddress(ws_cli_conn_t *client);
+	extern char *ws_getport(ws_cli_conn_t *client);
+	
 	extern int ws_sendframe(
 		ws_cli_conn_t *cli, const char *msg, uint64_t size, int type);
 	extern int ws_sendframe_txt(ws_cli_conn_t *cli, const char *msg);
 	extern int ws_sendframe_bin(ws_cli_conn_t *cli, const char *msg, uint64_t size);
 	extern int ws_get_state(ws_cli_conn_t *cli);
 	extern int ws_close_client(ws_cli_conn_t *cli);
-	extern int ws_socket(struct ws_events *evs, const char* host, uint16_t port, int thread_loop,
+	extern int ws_socket(struct ws_events *evs, const char *host, const char *port, int thread_loop,
 		uint32_t timeout_ms);
 
 	/* Ping routines. */

--- a/include/ws.h
+++ b/include/ws.h
@@ -264,7 +264,7 @@ extern "C" {
 	extern int ws_sendframe_bin(ws_cli_conn_t *cli, const char *msg, uint64_t size);
 	extern int ws_get_state(ws_cli_conn_t *cli);
 	extern int ws_close_client(ws_cli_conn_t *cli);
-	extern int ws_socket(struct ws_events *evs, uint16_t port, int thread_loop,
+	extern int ws_socket(struct ws_events *evs, const char* host, uint16_t port, int thread_loop,
 		uint32_t timeout_ms);
 
 	/* Ping routines. */

--- a/src/ws.c
+++ b/src/ws.c
@@ -1621,13 +1621,14 @@ static void *ws_accept(void *data)
  * @return If @p thread_loop != 0, returns 0. Otherwise, never
  * returns.
  */
-int ws_socket(struct ws_events *evs, uint16_t port, int thread_loop,
-	uint32_t timeout_ms)
+int ws_socket(struct ws_events *evs, const char* host, uint16_t port, 
+	int thread_loop, uint32_t timeout_ms)
 {
 	struct sockaddr_in server; /* Server.                */
 	pthread_t accept_thread;   /* Accept thread.         */
 	int reuse;                 /* Socket option.         */
 	int *sock;                 /* Client sock.           */
+	in_addr_t host_addr;       /* Address to bind to.    */
 
 	timeout = timeout_ms;
 
@@ -1679,7 +1680,13 @@ int ws_socket(struct ws_events *evs, uint16_t port, int thread_loop,
 
 	/* Prepare the sockaddr_in structure. */
 	server.sin_family = AF_INET;
-	server.sin_addr.s_addr = INADDR_ANY;
+
+	if (host == NULL) {
+		server.sin_addr.s_addr = INADDR_ANY;
+	} else {
+		server.sin_addr.s_addr = inet_addr(host);
+	}
+
 	server.sin_port = htons(port);
 
 	/* Bind. */


### PR DESCRIPTION
I wanted to be able to bind to localhost where I use wsServer for reverse proxying purposes, which means it would also be helpful if I could see which client port it was connecting from.  One of the localhost interfaces I bind to is ::1, so some changes were necessary to fit ipv6 into it.

I guess this modernizes things a bit?

The main API change is that ws_socket requires a host char*, though setting it to NULL returns it to the previous behavior.   Also, the port is also a char* now.