### PR TITLE
define function `ws_send_broadcast`

### DIFF
--- a/include/ws.h
+++ b/include/ws.h
@@ -267,6 +267,8 @@ extern "C" {
 	extern int ws_socket(struct ws_events *evs, uint16_t port, int thread_loop,
 		uint32_t timeout_ms);
 
+    extern int ws_send_broacast(
+        ws_cli_conn_t * client, const char * msg, uint64_t size, int type);
 	/* Ping routines. */
 	extern void ws_ping(ws_cli_conn_t *cli, int threshold);
 


### PR DESCRIPTION
For example chat room an client send to server message with content **"hi all"**
when server received and send message to all client in room and exclude
client because that message send back to client not necessary.

Thus check client is NULL to send broadcast is not perfect, so we define function
`ws_send_broadcast` to fix this problem