### PR TITLE
Added client context, with a disclaimer that it can be re-used.

### DIFF
--- a/include/ws.h
+++ b/include/ws.h
@@ -228,6 +228,18 @@ extern "C" {
 	typedef struct ws_connection ws_cli_conn_t;
 
 	/**
+	 * @brief Set client context.
+	 * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+	 */
+	void ws_set_client_context(ws_cli_conn_t *cli, void *ptr);
+
+	/**
+	 * @brief Get client context.
+	 * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+	 */
+	void *ws_get_client_context(ws_cli_conn_t *cli);
+
+	/**
 	 * @brief events Web Socket events types.
 	 */
 	struct ws_events
@@ -274,6 +286,11 @@ extern "C" {
 		 * @brief Server events.
 		 */
 		struct ws_events evs;
+		/**
+		 * @brief Client context.
+		 * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+		 */
+		void* client_context;
 	};
 
 	/* Forward declarations. */

--- a/src/ws.c
+++ b/src/ws.c
@@ -90,6 +90,24 @@ struct ws_connection
 };
 
 /**
+ * @brief Set client context.
+ * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+ */
+void ws_set_client_context(ws_cli_conn_t *cli, void *ptr)
+{
+	cli->ws_srv.client_context = ptr;
+}
+
+/**
+ * @brief Get client context.
+ * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+ */
+void *ws_get_client_context(struct ws_connection* cli)
+{
+	return cli->ws_srv.client_context;
+}
+
+/**
  * @brief Clients list.
  */
 static struct ws_connection client_socks[MAX_CLIENTS];


### PR DESCRIPTION
@Theldus , this follows your comment from  2022: https://github.com/Theldus/wsServer/issues/48#issuecomment-1110182182.

Pls kindly let me sleep over how to best handle the fact that the same client context may be re-used.