### PR TITLE
Added `target_include_directories` for the `ws` target.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,8 @@ add_library(ws
     src/utf8.c
 )
 
+target_include_directories(ws INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+
 if(WIN32)
 	target_link_libraries(ws pthread ws2_32 -static)
 else()


### PR DESCRIPTION
Added `target_include_directories`, so that the users who depend on the `ws` target from `CMakeLists.txt` in this repo can just `#include "include/ws.h"` without having to worry about paths.