### PR TITLE
Made it possible to set client context for the listening server too.

### DIFF
--- a/include/ws.h
+++ b/include/ws.h
@@ -227,6 +227,9 @@ extern "C" {
 	/* Opaque client connection type. */
 	typedef struct ws_connection ws_cli_conn_t;
 
+	/* Opaque server instance type. */
+	typedef struct ws_server ws_server_t;
+
 	/**
 	 * @brief Set client context.
 	 * Note that the same `ws_cli_conn_t` instance can be reused across connections.
@@ -238,6 +241,18 @@ extern "C" {
 	 * Note that the same `ws_cli_conn_t` instance can be reused across connections.
 	 */
 	void *ws_get_client_context(ws_cli_conn_t *cli);
+
+	/**
+	 * @brief Set client context for the server.
+	 * Note that it can outlive a single connection.
+	 */
+	void ws_server_set_client_context(ws_server_t *ws_srv, void *ptr);
+
+	/**
+	 * @brief Get client context for the server.
+	 * Note that it can outlive a single connection.
+	 */
+	void *ws_server_get_client_context(ws_server_t *ws_srv);
 
 	/**
 	 * @brief events Web Socket events types.

--- a/include/ws.h
+++ b/include/ws.h
@@ -231,28 +231,20 @@ extern "C" {
 	typedef struct ws_server ws_server_t;
 
 	/**
-	 * @brief Set client context.
-	 * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+	 * @brief Get server context.
+	 * Set when initializing `.context` in `struct ws_server`.
 	 */
-	void ws_set_client_context(ws_cli_conn_t *cli, void *ptr);
+	void *ws_get_server_context(ws_cli_conn_t *cli);
 
 	/**
-	 * @brief Get client context.
-	 * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+	 * @brief Set connection context.
 	 */
-	void *ws_get_client_context(ws_cli_conn_t *cli);
+	void ws_set_connection_context(ws_cli_conn_t *cli, void *ptr);
 
 	/**
-	 * @brief Set client context for the server.
-	 * Note that it can outlive a single connection.
+	 * @brief Get connection context.
 	 */
-	void ws_server_set_client_context(ws_server_t *ws_srv, void *ptr);
-
-	/**
-	 * @brief Get client context for the server.
-	 * Note that it can outlive a single connection.
-	 */
-	void *ws_server_get_client_context(ws_server_t *ws_srv);
+	void *ws_get_connection_context(ws_cli_conn_t *cli);
 
 	/**
 	 * @brief events Web Socket events types.
@@ -302,10 +294,10 @@ extern "C" {
 		 */
 		struct ws_events evs;
 		/**
-		 * @brief Client context.
-		 * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+		 * @brief Server context.
+		 * Provided by the user, can be accessed via `ws_get_server_context` from `onopen`.
 		 */
-		void* client_context;
+		void* context;
 	};
 
 	/* Forward declarations. */

--- a/src/ws.c
+++ b/src/ws.c
@@ -102,9 +102,27 @@ void ws_set_client_context(ws_cli_conn_t *cli, void *ptr)
  * @brief Get client context.
  * Note that the same `ws_cli_conn_t` instance can be reused across connections.
  */
-void *ws_get_client_context(struct ws_connection* cli)
+void *ws_get_client_context(ws_cli_conn_t *cli)
 {
 	return cli->ws_srv.client_context;
+}
+
+/**
+ * @brief Set client context for the server.
+ * Note that it can outlive a single connection.
+ */
+void ws_server_set_client_context(ws_server_t *ws_srv, void *ptr)
+{
+	ws_srv->client_context = ptr;
+}
+
+/**
+ * @brief Get client context for the server.
+ * Note that it can outlive a single connection.
+ */
+void *ws_server_get_client_context(ws_server_t* ws_srv)
+{
+	return ws_srv->client_context;
 }
 
 /**

--- a/src/ws.c
+++ b/src/ws.c
@@ -87,42 +87,34 @@ struct ws_connection
 	int32_t last_pong_id;
 	int32_t current_ping_id;
 	pthread_mutex_t mtx_ping;
+
+	/* Connection context */
+	void *connection_context;
 };
 
 /**
- * @brief Set client context.
- * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+ * @brief Get server context.
+ * Assumed to be set once, when initializing `.context` in `struct ws_server`.
  */
-void ws_set_client_context(ws_cli_conn_t *cli, void *ptr)
+void *ws_get_server_context(ws_cli_conn_t *cli)
 {
-	cli->ws_srv.client_context = ptr;
+	return cli->ws_srv.context;
 }
 
 /**
- * @brief Get client context.
- * Note that the same `ws_cli_conn_t` instance can be reused across connections.
+ * @brief Set connection context.
  */
-void *ws_get_client_context(ws_cli_conn_t *cli)
+void ws_set_connection_context(ws_cli_conn_t *cli, void *ptr)
 {
-	return cli->ws_srv.client_context;
+	cli->connection_context = ptr;
 }
 
 /**
- * @brief Set client context for the server.
- * Note that it can outlive a single connection.
+ * @brief Get connection context.
  */
-void ws_server_set_client_context(ws_server_t *ws_srv, void *ptr)
+void *ws_get_connection_context(ws_cli_conn_t *cli)
 {
-	ws_srv->client_context = ptr;
-}
-
-/**
- * @brief Get client context for the server.
- * Note that it can outlive a single connection.
- */
-void *ws_server_get_client_context(ws_server_t* ws_srv)
-{
-	return ws_srv->client_context;
+	return cli->connection_context;
 }
 
 /**


### PR DESCRIPTION
Hi @Theldus,

Slept over what we introduced in https://github.com/Theldus/wsServer/pull/91 yesterday.

Yes, it will have to be the client's responsibility to be mindful that the client context pointer will persist across connections. The clients for whom this matters should use the `onclose` handler then.

Also, I realized it can be needed to set the client context before the connection is established, just as the server begins listening. And here is the PR.

The issue ID remains the same, https://github.com/Theldus/wsServer/issues/48.

Thanks,
Dima