### PR TITLE
toyws: cpp compability; return frame length on tws_receiveframe

### DIFF
--- a/extra/toyws/toyws.c
+++ b/extra/toyws/toyws.c
@@ -318,7 +318,7 @@ static int skip_frame(struct tws_ctx *ctx, uint64_t frame_size)
  * @param buff_size Buffer size.
  * @param frm_type Frame type received.
  *
- * @return Returns 0 if success, a negative number
+ * @return Returns frame length if success, a negative number
  * otherwise.
  */
 int tws_receiveframe(struct tws_ctx *ctx, char **buff,
@@ -397,7 +397,7 @@ int tws_receiveframe(struct tws_ctx *ctx, char **buff,
 	{
 		cur_byte = next_byte(ctx, &ret);
 		if (cur_byte < 0)
-			return (ret);
+			return (ret == 0 ? frame_length : ret);
 
 		*buf = cur_byte;
 	}
@@ -406,5 +406,5 @@ int tws_receiveframe(struct tws_ctx *ctx, char **buff,
 	/* Fill other infos. */
 	*frm_type = opcode;
 
-	return (ret);
+	return (ret == 0 ? frame_length : ret);
 }

--- a/extra/toyws/toyws.h
+++ b/extra/toyws/toyws.h
@@ -43,6 +43,10 @@
 		int fd;
 	};
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 	/* External functions. */
 	extern int tws_connect(struct tws_ctx *ctx, const char *ip,
 		uint16_t port);
@@ -51,5 +55,9 @@
 		uint64_t size, int type);
 	extern int tws_receiveframe(struct tws_ctx *ctx, char **buff,
 		size_t *buff_size, int *frm_type);
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif /* TOYWS_H */


### PR DESCRIPTION
Description
-----------

The are two changes:
* added extern "C" in case if compiler is cpp. This allow to use toyws from cpp code
* tws_receiveframe returns frame_length instead of zero (on success). without this change if you use own buffer in tws_receiveframe then you can't know the real frame size, cause size remains the same.
 
Checklist
---------
- [X] I've read the notice in the PR template before submitting it
- My PR is:
  - Trivial and:
    - [ ] I've created an issue (please mention the issue number)
    - [X] I haven't created an issue (thats ok...)
  - Non-trivial:
    - Issue number:
