### PR TITLE
Fixed include dir path for cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ add_library(ws
     src/utf8.c
 )
 
-target_include_directories(ws INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}")
+target_include_directories(ws INTERFACE "${CMAKE_CURRENT_SOURCE_DIR}/include")
 
 if(WIN32)
 	target_link_libraries(ws pthread ws2_32 -static)


### PR DESCRIPTION
Description
-----------
When this library is used with CMake FetchContent:

```cmake
FetchContent_Declare(
  wsServer
  GIT_REPOSITORY https://github.com/Theldus/wsServer.git
)
FetchContent_MakeAvailable(wsServer)
``` 
the project fails to compile due to missing include directory. 
This PR fixes that.

Checklist
---------
- [x] I've read the notice in the PR template before submitting it
- My PR is:
  - Trivial and:
    - [x] I haven't created an issue 


