### PR TITLE
Reject invalid Sec-WebSocket-Key values

### DIFF
--- a/src/handshake.c
+++ b/src/handshake.c
@@ -47,13 +47,26 @@
  */
 int get_handshake_accept(char *wsKey, unsigned char **dest)
 {
+	unsigned char *decoded;            /* Decoded WebSocket key.       */
 	unsigned char hash[SHA1HashSize]; /* SHA-1 Hash.                   */
 	SHA1Context ctx;                  /* SHA-1 Context.                */
 	char *str;                        /* WebSocket key + magic string. */
+	size_t decoded_len;               /* Decoded key length.           */
 
 	/* Invalid key. */
-	if (!wsKey)
+	if (!wsKey || strlen(wsKey) != WS_KEY_LEN ||
+		wsKey[WS_KEY_LEN - 2] != '=' ||
+		wsKey[WS_KEY_LEN - 1] != '=')
 		return (-1);
+
+	decoded = base64_decode((const unsigned char *)wsKey, WS_KEY_LEN,
+		&decoded_len);
+	if (!decoded || decoded_len != 16)
+	{
+		free(decoded);
+		return (-1);
+	}
+	free(decoded);
 
 	str = calloc(1, sizeof(char) * (WS_KEY_LEN + WS_MS_LEN + 1));
 	if (!str)


### PR DESCRIPTION
Description
-----------
RFC 6455 requires `Sec-WebSocket-Key` to be a Base64 value that decodes to
exactly 16 bytes. Before this fix, malformed keys could still produce a
`101 Switching Protocols` response.

This revision rejects a key unless it has the required 24-character padded
form and the existing Base64 decoder produces exactly 16 bytes. The previous
variable-length SHA-1 change is removed, so the accepted key and GUID are
hashed using the existing `WS_KEYMS_LEN` length.

Verification
------------
- Reproduced the old behavior with short, invalid-alphabet, and 18-byte keys.
- Verified the RFC example still produces
  `s3pPLMBiTxaQ9kYGzzhZRbK+xOo=`.
- Verified short, overlong, invalid-alphabet, bad-padding, embedded-padding,
  and 18-byte keys are rejected by the complete handshake-response path.
- Built the library and all examples with CMake/Ninja on MinGW GCC 8.1.0.
- Compiled the focused regression harness with `-Werror -pedantic`.

Checklist
---------
- [x] I've read the notice in the PR template before submitting it
- My PR is:
  - Trivial and:
    - [ ] I've created an issue (please mention the issue number)
    - [x] I haven't created an issue (thats ok...)
  - Non-trivial:
    - Issue number: N/A
